### PR TITLE
(add) client request reception using net/http

### DIFF
--- a/handlerFunc_three_chain/handlerFunc_three_chain.go
+++ b/handlerFunc_three_chain/handlerFunc_three_chain.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"runtime"
+)
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hello!")
+}
+
+func log(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		name := runtime.FuncForPC(reflect.ValueOf(h).Pointer()).Name()
+		fmt.Println("Handler function called - " + name)
+		h(w, r)
+	}
+}
+
+func protect(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// some code that check user authorized
+		h(w, r)
+	}
+}
+
+func main() {
+	server := http.Server{
+		Addr: "127.0.0.1:8080",
+	}
+
+	http.HandleFunc("/hello", protect(log(hello)))
+	server.ListenAndServe()
+}

--- a/handlerFunc_two_chain/handlerFunc_two_chain.go
+++ b/handlerFunc_two_chain/handlerFunc_two_chain.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"runtime"
+)
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hello!")
+}
+
+func log(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		name := runtime.FuncForPC(reflect.ValueOf(h).Pointer()).Name()
+		fmt.Println("Handler function called - " + name)
+		h(w, r)
+	}
+}
+
+func main() {
+	server := http.Server{
+		Addr: "127.0.0.1:8080",
+	}
+
+	http.HandleFunc("/hello", log(hello))
+	server.ListenAndServe()
+}

--- a/handler_three_chain/go.mod
+++ b/handler_three_chain/go.mod
@@ -1,0 +1,3 @@
+module example.com/handler_three_chain
+
+go 1.14

--- a/handler_three_chain/handler_three_chain.go
+++ b/handler_three_chain/handler_three_chain.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// HelloHandler is simple return "Hello!"
+type HelloHandler struct{}
+
+func (h HelloHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hello!")
+}
+
+func log(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("Handler function called - %T\n", h)
+		h.ServeHTTP(w, r)
+	})
+}
+
+func protect(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// some code that check user authorized
+		h.ServeHTTP(w, r)
+	})
+}
+
+func main() {
+	server := http.Server{
+		Addr: "127.0.0.1:8080",
+	}
+	hello := HelloHandler{}
+	http.Handle("/hello", protect(log(hello)))
+	server.ListenAndServe()
+}

--- a/http_router_mux/go.mod
+++ b/http_router_mux/go.mod
@@ -1,0 +1,5 @@
+module example.com/http_router_mux
+
+go 1.14
+
+require github.com/julienschmidt/httprouter v1.3.0

--- a/http_router_mux/go.sum
+++ b/http_router_mux/go.sum
@@ -1,0 +1,2 @@
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/http_router_mux/http_router_mux.go
+++ b/http_router_mux/http_router_mux.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+func hello(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+	fmt.Fprintf(w, "hello, %s!\n", p.ByName("name"))
+}
+
+func main() {
+	mux := httprouter.New()
+	mux.GET("/hello/:name", hello)
+
+	server := http.Server{
+		Addr:    "127.0.0.1:8080",
+		Handler: mux,
+	}
+
+	server.ListenAndServe()
+}

--- a/multi_handler_serveHTTP/multi_handler_serveHTTP.go
+++ b/multi_handler_serveHTTP/multi_handler_serveHTTP.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// HelloHandler is simple return "Hello!"
+type HelloHandler struct{}
+
+func (h *HelloHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hello!")
+}
+
+// WorldHandler is simple return "World!"
+type WorldHandler struct{}
+
+func (h *WorldHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "World!")
+}
+
+func main() {
+	hello := HelloHandler{}
+	world := WorldHandler{}
+
+	server := http.Server{
+		Addr:    "127.0.0.1:8080",
+		Handler: nil,
+	}
+
+	http.Handle("/hello", &hello)
+	http.Handle("/world", &world)
+	server.ListenAndServe()
+}

--- a/multi_handlerfunc_serveHTTP/multi_handlerfunc_serveHTTP.go
+++ b/multi_handlerfunc_serveHTTP/multi_handlerfunc_serveHTTP.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hello!")
+}
+
+func world(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "World!")
+}
+
+func main() {
+	server := http.Server{
+		Addr:    "127.0.0.1:8080",
+		Handler: nil,
+	}
+
+	http.HandleFunc("/hello", hello)
+	http.HandleFunc("/world", world)
+	server.ListenAndServe()
+}


### PR DESCRIPTION
## リクエストの受付をnet/httpライブラリで実装
- マルチプレクサはハンドラの振り分けだけをする係
- ハンドラはマルチプレクサがURLを通じて呼ばれたら処理をする係
  - レスポンスに書き込むのだろうが今はまだ詳しくわかってない
- ハンドラは関数を引数として受け取れるためハンドラのチェインニングが行える(パイプライン処理)
  - scikitlearnのパイプライン処理と似ている
- 時と場合に応じてマルチプレクサはサードパーティのライブラリを使った方がいい場合がある
  - デフォルトのserveMuxはURLとのパターンマッチに変数が使えないデメリットがある

## 面白そうな言葉
- カーゴカルト・プログラミング
- 驚き最小の原則
- cURL
